### PR TITLE
Indicating conference not always held

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 	    <strong><a id="Conference"></a>Welcome to the Consortium for Software Engineering Research!</strong>
 	    <br>
 	    <p>
-	    	The aim of the Consortium for Software Engineering Research (CSER) is to bring together (primarily) Canadian-based researchers and practitioners working on research problems in software engineering. We meet twice a year in the spring and fall. Fall meetings are typically co-located with the IBM CAS conference (CASCON).
+	    	The aim of the Consortium for Software Engineering Research (CSER) is to bring together (primarily) Canadian-based researchers and practitioners working on research problems in software engineering. We normally meet twice a year in the spring and fall. Fall meetings are typically co-located with the IBM CAS conference (CASCON).
 	    </p>
 	    <p>
 	    	<large> <a href="https://www.cser.ca/2020s/">CSER 2020 Spring Meeting, in Ottawa (Cancelled due to Covid-19).</a> The next event will be the Fall 2020 CSER. The Spring 2021 event will be in Ottawa..</large>


### PR DESCRIPTION
The conference was cancelled in 2020 so we are saying it is normally not always held